### PR TITLE
Fix deleting a song from a separate folder's level pack

### DIFF
--- a/Loader.cs
+++ b/Loader.cs
@@ -689,6 +689,9 @@ namespace SongCore
                 {
                     CustomWIPLevels.Remove(folderPath);
 
+                    foreach (var folderEntry in SeperateSongFolders)
+                        folderEntry.Levels.Remove(folderPath);
+
                     if (Collections.levelHashDictionary.ContainsKey(level.levelID))
                     {
                         string hash = Collections.hashForLevelID(level.levelID);


### PR DESCRIPTION
Before this fix, when deleting a song from a level pack generated for a separate folder, the deleted song's IPreviewBeatmapLevel wouldn't get removed from the beatmap collection (or more accurately, would get re-inserted into the collection during the call to RefreshLevelPacks). This caused the level to still appear in the UI and thrown an exception when selected.