### PR TITLE
Daily reminder to add BSIPA to your dependencies

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,10 +8,9 @@
   "version": "2.9.12",
   "dependsOn": {
     "BeatSaberMarkupLanguage": "^1.3.2",
+    "BSIPA": "^4.0.5",
     "BS Utils": "^1.4.9"
   },
-  "features": [
-  ],
   "links": {
     "project-source": "https://github.com/Kylemc1413/SongCore"
   }


### PR DESCRIPTION
This PR was mainly meant to add BSIPA as a dependency to the manifest because it will be a requirement soon™.
Also yeeted the features part from the manifest while we're at it, because it throws warnings and didn't do anything functional.