### PR TITLE
Improved custom song loading speed a lot

### DIFF
--- a/Collections.cs
+++ b/Collections.cs
@@ -2,6 +2,7 @@
 using SongCore.Data;
 using SongCore.Utilities;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,9 +15,9 @@ namespace SongCore
 
 
         internal static string dataPath = Path.Combine(IPA.Utilities.UnityGame.InstallPath, "UserData", "SongCore", "SongCoreExtraData.dat");
-        internal static Dictionary<string, ExtraSongData> customSongsData = new Dictionary<string, ExtraSongData>();
-        internal static Dictionary<string, string> levelHashDictionary = new Dictionary<string, string>();
-        internal static Dictionary<string, List<string>> hashLevelDictionary = new Dictionary<string, List<string>>();
+        internal static ConcurrentDictionary<string, ExtraSongData> customSongsData = new ConcurrentDictionary<string, ExtraSongData>();
+        internal static ConcurrentDictionary<string, string> levelHashDictionary = new ConcurrentDictionary<string, string>();
+        internal static ConcurrentDictionary<string, List<string>> hashLevelDictionary = new ConcurrentDictionary<string, List<string>>();
         private static List<string> _capabilities = new List<string>();
         public static System.Collections.ObjectModel.ReadOnlyCollection<string> capabilities
         {
@@ -53,7 +54,7 @@ namespace SongCore
         public static void AddSong(string levelID, string path)
         {
             if (!customSongsData.ContainsKey(levelID))
-                customSongsData.Add(levelID, new ExtraSongData(levelID, path));
+                customSongsData.TryAdd(levelID, new ExtraSongData(levelID, path));
             //         Utilities.Logging.Log("Entry: :"  + levelID + "    " + customSongsData.Count);
         }
 
@@ -89,17 +90,15 @@ namespace SongCore
         }
         public static void LoadExtraSongData()
         {
-            customSongsData = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, ExtraSongData>>(File.ReadAllText(dataPath));
+            customSongsData = Newtonsoft.Json.JsonConvert.DeserializeObject<ConcurrentDictionary<string, ExtraSongData>>(File.ReadAllText(dataPath));
             if (customSongsData == null)
-                customSongsData = new Dictionary<string, ExtraSongData>();
+                customSongsData = new ConcurrentDictionary<string, ExtraSongData>();
         }
 
         public static void SaveExtraSongData()
         {
             File.WriteAllText(dataPath, Newtonsoft.Json.JsonConvert.SerializeObject(customSongsData, Formatting.None));
         }
-
-
 
         public static void RegisterCapability(string capability)
         {

--- a/ProgressBar.cs
+++ b/ProgressBar.cs
@@ -1,5 +1,6 @@
 ﻿using SongCore.Utilities;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -105,10 +106,10 @@ namespace SongCore
             _canvas.enabled = true;
         }
 
-        private void SongLoaderOnSongsLoadedEvent(Loader arg1, Dictionary<string, CustomPreviewBeatmapLevel> arg2)
+        private void SongLoaderOnSongsLoadedEvent(Loader loader, ConcurrentDictionary<string, CustomPreviewBeatmapLevel> customLevels)
         {
             _showingMessage = false;
-            _headerText.text = arg2.Count + " songs loaded.";
+            _headerText.text = customLevels.Count + " songs loaded.";
             _loadingBar.enabled = false;
             _loadingBackg.enabled = false;
             StartCoroutine(DisableCanvasRoutine(5f));


### PR DESCRIPTION
This PR aims to improve the loading speed of custom songs by processing custom songs in a parallel manner.
By general testing, it resulting in a ~3x  performance improvement (however your milage may vary)

However as a side-effect, all dictionaries had to be changed to their Concurrent counterpart (`ConcurrentDictionary`) and with that also breaking the public facing API of SongCore. This means that many mods will be broken and will need a recompile and most likely also a slight change of methods.

Feel free to let me know anything that has to be changed.
