### PR TITLE
 Trolav 2020.10.22 - Support beatmap caching for seperate song folders & minor restructuring

### DIFF
--- a/Collections.cs
+++ b/Collections.cs
@@ -127,7 +127,7 @@ namespace SongCore
             return null;
         }
         //SongFolderEntry(string name, string path, FolderLevelPack pack, string imagePath = "", bool wip = false)
-        public static SeperateSongFolder AddSeperateSongFolder(string name, string folderPath, FolderLevelPack pack, Sprite image = null, bool wip = false)
+        public static SeperateSongFolder AddSeperateSongFolder(string name, string folderPath, FolderLevelPack pack, Sprite image = null, bool wip = false, bool cachezips = false)
         {
             UI.BasicUI.GetIcons();
             if (!Directory.Exists(folderPath))
@@ -141,7 +141,7 @@ namespace SongCore
                     Logging.logger.Error("Failed to make folder for: " + name + "\n" + ex);
                 }
             }
-            Data.SongFolderEntry entry = new SongFolderEntry(name, folderPath, pack, "", wip);
+            Data.SongFolderEntry entry = new SongFolderEntry(name, folderPath, pack, "", wip, cachezips);
             ModSeperateSongFolder seperateSongFolder = new ModSeperateSongFolder(entry, image == null ? UI.BasicUI.FolderIcon : image);
             if (Loader.SeperateSongFolders == null) Loader.SeperateSongFolders = new List<SeperateSongFolder>();
             Loader.SeperateSongFolders.Add(seperateSongFolder);

--- a/Data/folders.xml
+++ b/Data/folders.xml
@@ -6,6 +6,7 @@
 		<Pack> either 0, 1, or 2. 0 means the songs will be put in the main custom levels pack, 1 means it will be put in the wip levels pack, and 2 means it will be put into a new pack </Pack>
 		<ImagePath> If Pack is 2, will attempt to load this image to use as the pack cover. Use the Full Path to the Image </ImagePath>
 		<WIP> If Pack is 2, songs in this folder will be treated as WIP and only be playable in practice mode. Use True/False for the value </WIP>
+    <CacheZIPs> If set to true, SongCore will unzip the archives in this folder and show them as a seperate level pack in game </CacheZIPs>
 
 		</folder>
 		

--- a/HarmonyPatches/CustomCharacteristicsPatch.cs
+++ b/HarmonyPatches/CustomCharacteristicsPatch.cs
@@ -1,7 +1,6 @@
 ﻿using HarmonyLib;
 using System.Linq;
 using UnityEngine;
-using UnityEngine;
 namespace SongCore.HarmonyPatches
 {
 

--- a/OverrideClasses/SongCoreBeatmapLevelPackCollectionSO.cs
+++ b/OverrideClasses/SongCoreBeatmapLevelPackCollectionSO.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using SongCore.Utilities;
+using System.Collections.Generic;
 using System.Linq;
 namespace SongCore.OverrideClasses
 {
@@ -24,17 +25,25 @@ namespace SongCore.OverrideClasses
 
         public void AddLevelPack(CustomBeatmapLevelPack pack)
         {
-            _customBeatmapLevelPacks.Add(pack);
-            UpdateArray();
+            if (pack != null && !_customBeatmapLevelPacks.Contains(pack))
+            {
+                _customBeatmapLevelPacks.Add(pack);
+                UpdateArray();
+            }
+        }
+
+        public void RemoveLevelPack(CustomBeatmapLevelPack pack)
+        {
+            if (pack != null && _customBeatmapLevelPacks.Contains(pack))
+            {
+                _customBeatmapLevelPacks.Remove(pack);
+                UpdateArray();
+            }
         }
 
         private void UpdateArray()
         {
-            var packs = _allBeatmapLevelPacks.ToList();
-            foreach (var c in _customBeatmapLevelPacks)
-                if (!packs.Contains(c))
-                    packs.Add(c);
-            _allBeatmapLevelPacks = packs.ToArray();
+            _allBeatmapLevelPacks = _customBeatmapLevelPacks.ToArray();
         }
 
     }


### PR DESCRIPTION
- Added an additional value (CacheZIPs) to "folders.xml"
  - If set to "True", ZIPs in that folder will be unzipped to subfolder "Cache"
  - If level pack is either CustomLevels ("0") or New Pack ("2"), the cache folder will be a seperate map pack -> New Pack ("2")
  - If level pack is CustomWIPLevels, the unzipped beatmaps will be added to CachedWIPLevels ("3" [new])
- Level packs will be overwritten on pack addition / deletion
- Created helper functions for duplicate code
- Added regions for structure
- Added some comments