### PR TITLE
Container Refreshing + Event via Zenject

### DIFF
--- a/HarmonyPatches/MainSystemsInitRefreshablePatch.cs
+++ b/HarmonyPatches/MainSystemsInitRefreshablePatch.cs
@@ -1,4 +1,6 @@
 ﻿using HarmonyLib;
+using System;
+using System.Collections.Concurrent;
 using Zenject;
 
 namespace SongCore.HarmonyPatches
@@ -6,9 +8,15 @@ namespace SongCore.HarmonyPatches
     [HarmonyPatch(typeof(MainSystemInit), nameof(MainSystemInit.InstallBindings))]
     public class MainSystemsInitRefreshablePatch
     {
+        public const string refreshableID = "SongCore.Loader.Refresh";
+        public const string didLoadEventID = "SongCore.Loader.Loaded";
+
         static void Postfix(DiContainer container)
         {
-            container.Bind<IRefreshable>().WithId($"{nameof(SongCore)}.{nameof(Loader)}").To<SongCoreRefreshable>().AsSingle();
+            container.Bind<IRefreshable>().WithId(refreshableID).To<SongCoreRefreshable>().AsSingle();
+            container.Bind(typeof(IInitializable), typeof(IDisposable), typeof(SongCoreLoaderDidLoad)).To<SongCoreLoaderDidLoad>().AsSingle();
+            IObservableChange loadEvent = container.Resolve<SongCoreLoaderDidLoad>();
+            container.BindInstance(loadEvent).WithId(didLoadEventID).AsSingle();
         }
 
         private class SongCoreRefreshable : IRefreshable
@@ -19,6 +27,26 @@ namespace SongCore.HarmonyPatches
                 {
                     Loader.Instance.RefreshSongs();
                 }
+            }
+        }
+
+        private class SongCoreLoaderDidLoad : IInitializable, IDisposable, IObservableChange
+        {
+            public event Action didChangeEvent;
+
+            public void Initialize()
+            {
+                Loader.SongsLoadedEvent += Loader_SongsLoadedEvent;
+            }
+
+            private void Loader_SongsLoadedEvent(Loader _, ConcurrentDictionary<string, CustomPreviewBeatmapLevel> __)
+            {
+                didChangeEvent?.Invoke();
+            }
+
+            public void Dispose()
+            {
+                Loader.SongsLoadedEvent -= Loader_SongsLoadedEvent;
             }
         }
     }

--- a/HarmonyPatches/MainSystemsInitRefreshablePatch.cs
+++ b/HarmonyPatches/MainSystemsInitRefreshablePatch.cs
@@ -1,0 +1,25 @@
+﻿using HarmonyLib;
+using Zenject;
+
+namespace SongCore.HarmonyPatches
+{
+    [HarmonyPatch(typeof(MainSystemInit), nameof(MainSystemInit.InstallBindings))]
+    public class MainSystemsInitRefreshablePatch
+    {
+        static void Postfix(DiContainer container)
+        {
+            container.Bind<IRefreshable>().WithId($"{nameof(SongCore)}.{nameof(Loader)}").To<SongCoreRefreshable>().AsSingle();
+        }
+
+        private class SongCoreRefreshable : IRefreshable
+        {
+            public void Refresh()
+            {
+                if (Loader.AreSongsLoaded)
+                {
+                    Loader.Instance.RefreshSongs();
+                }
+            }
+        }
+    }
+}

--- a/SongCore.csproj
+++ b/SongCore.csproj
@@ -157,6 +157,16 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.XRModule.dll</HintPath>
     </Reference>
+    <Reference Include="Zenject, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Zenject-usage, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Collections.cs" />
@@ -166,6 +176,7 @@
     <Compile Include="HarmonyPatches\ClampPatches.cs" />
     <Compile Include="HarmonyPatches\BeatmapDifficultyMethodsName.cs" />
     <Compile Include="HarmonyPatches\AprilFools.cs" />
+    <Compile Include="HarmonyPatches\MainSystemsInitRefreshablePatch.cs" />
     <Compile Include="HarmonyPatches\PlatformsPatch.cs" />
     <Compile Include="HarmonyPatches\CustomCharacteristicsPatch.cs" />
     <Compile Include="HarmonyPatches\CustomSongColorsPatch.cs" />


### PR DESCRIPTION
This is a very simple PR which exposes the SongCore refresh ability and load event to the main zenject container via the base game's `IRefreshable` interface and `IObservableChange` event respectively.

**Why?**

Some people (myself included) like to keep dependencies down as much as possible, this helps with that since it's no longer required to reference SongCore directly in order to (just) refresh songs or to (just) know when songs have been loaded (something that I personally realized is the only reason why I'm referencing SongCore for). Mods using Zenject can optionally request the two interfaces through their IDs and use their appropriate methods.

This is especially useful during times of updates where a mod needs to use (occasionally or optionally) use these features but SongCore hasn't been updated yet.