### PR TITLE
Increase mapper name font size and highlight it

### DIFF
--- a/HarmonyPatches/LevelSelectionPatch.cs
+++ b/HarmonyPatches/LevelSelectionPatch.cs
@@ -35,7 +35,7 @@ namespace SongCore.HarmonyPatches
             ____songAuthorText.richText = true;
             if (!string.IsNullOrWhiteSpace(customLevel.levelAuthorName))
             {
-                ____songAuthorText.text = $"{customLevel.songAuthorName} <size=80%>[{customLevel.levelAuthorName.Replace(@"<", "<\u200B").Replace(@">", ">\u200B")}]</size>";
+                ____songAuthorText.text = $"<size=80%>{customLevel.songAuthorName}</size> <size=90%>[<color=#89ff89>{customLevel.levelAuthorName.Replace(@"<", "<\u200B").Replace(@">", ">\u200B")}</color>]</size>";
             }
         }
     }


### PR DESCRIPTION
For now artist/mapper font size is 100%/80%, but artist/title info can also be seen on the right when you select a map.
So I think mapper name should have a priority (increased font size, different color) at least in the list.

<details><summary>Preview</summary>

![2021-08-04_181609](https://user-images.githubusercontent.com/16892631/128240950-02270ad5-d4ce-46d3-8ab7-e7e5260ecb82.png)
</details>
