### PR TITLE
Round BPM values in level list table, prevent icon overlap

### DIFF
--- a/HarmonyPatches/LevelSelectionPatch.cs
+++ b/HarmonyPatches/LevelSelectionPatch.cs
@@ -22,8 +22,11 @@ namespace SongCore.HarmonyPatches
     [HarmonyPatch("SetDataFromLevelAsync", MethodType.Normal)]
     internal class LevelListTableCellSetDataFromLevel
     {
-        private static void Postfix(IPreviewBeatmapLevel level, bool isFavorite, ref TextMeshProUGUI ____songAuthorText)
+        private static void Postfix(IPreviewBeatmapLevel level, bool isFavorite, ref TextMeshProUGUI ____songAuthorText, ref TextMeshProUGUI ____songBpmText)
         {
+            // Rounding BPM display for all maps, including official ones
+            ____songBpmText.text = System.Math.Round(level.beatsPerMinute).ToString();
+
             if (!(level is CustomPreviewBeatmapLevel customLevel))
             {
                 return;


### PR DESCRIPTION
Before:
![2021-08-08_165544](https://user-images.githubusercontent.com/16892631/128634742-156a1bc8-8325-4f42-a1ff-f953b2f50a7c.png)

After:
![2021-08-08_165827](https://user-images.githubusercontent.com/16892631/128634745-a8d7fafe-e915-415a-a44b-262f03817952.png)