### PR TITLE
Handle extra song data at load time

### DIFF
--- a/Data/SongData.cs
+++ b/Data/SongData.cs
@@ -1,7 +1,6 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
 using SongCore.Utilities;
@@ -9,6 +8,18 @@ using UnityEngine;
 
 namespace SongCore.Data
 {
+    public class SongData
+    {
+        public string RawSongData;
+        public StandardLevelInfoSaveData SaveData;
+
+        public SongData(string rawSongData, StandardLevelInfoSaveData saveData)
+        {
+            RawSongData = rawSongData;
+            SaveData = saveData;
+        }
+    }
+
     [Serializable]
     public class ExtraSongData
     {
@@ -83,18 +94,11 @@ namespace SongCore.Data
             _difficulties = difficulties;
         }
 
-        public ExtraSongData(string levelID, string songPath)
+        internal ExtraSongData(string rawSongData, string songPath)
         {
             try
             {
-                if (!File.Exists(Path.Combine(songPath, "info.dat")))
-                {
-                    return;
-                }
-
-                var infoText = File.ReadAllText(songPath + "/info.dat");
-
-                JObject info = JObject.Parse(infoText);
+                JObject info = JObject.Parse(rawSongData);
                 JObject infoData;
                 List<Contributor> levelContributors = new List<Contributor>();
                 //Check if song uses legacy value for full song One Saber mode

--- a/HarmonyPatches/LevelSelectionPatch.cs
+++ b/HarmonyPatches/LevelSelectionPatch.cs
@@ -1,23 +1,8 @@
-﻿using HarmonyLib;
-using SongCore.Utilities;
+using HarmonyLib;
 using TMPro;
 
 namespace SongCore.HarmonyPatches
 {
-    [HarmonyPatch(typeof(LevelCollectionViewController))]
-    [HarmonyPatch("HandleLevelCollectionTableViewDidSelectLevel", MethodType.Normal)]
-    internal class LevelPackLevelsSelectedPatch
-    {
-        private static void Prefix(LevelCollectionTableView tableView, IPreviewBeatmapLevel level)
-        {
-            if (level is CustomPreviewBeatmapLevel customLevel)
-            {
-                Collections.AddSong(Hashing.GetCustomLevelHash(customLevel), customLevel.customLevelPath);
-                Collections.SaveExtraSongData();
-            }
-        }
-    }
-
     [HarmonyPatch(typeof(LevelListTableCell))]
     [HarmonyPatch("SetDataFromLevelAsync", MethodType.Normal)]
     internal class LevelListTableCellSetDataFromLevel

--- a/HarmonyPatches/StandardLevelDetailViewRefreshContent.cs
+++ b/HarmonyPatches/StandardLevelDetailViewRefreshContent.cs
@@ -67,7 +67,7 @@ namespace SongCore.HarmonyPatches
                 return;
             }
 
-            var songData = Collections.RetrieveExtraSongData(Hashing.GetCustomLevelHash(level), level.customLevelPath);
+            var songData = Collections.RetrieveExtraSongData(Hashing.GetCustomLevelHash(level));
 
             if (songData == null)
             {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -119,8 +119,7 @@ namespace SongCore
         {
             if (level is CustomPreviewBeatmapLevel customLevel)
             {
-                var songData = Collections.RetrieveExtraSongData(Hashing.GetCustomLevelHash(customLevel), customLevel.customLevelPath);
-                Collections.SaveExtraSongData();
+                var songData = Collections.RetrieveExtraSongData(Hashing.GetCustomLevelHash(customLevel));
 
                 if (songData == null)
                 {


### PR DESCRIPTION
Improvements to #74.

This will require @Aeroluna to make small changes to CustomJSONData as it's now using a custom implementation of `CustomLevelLoader.LoadCustomLevelInfoSaveData` to load songs with their extra data.