### PR TITLE
Only load ExtraSongData when level can load

### DIFF
--- a/Loader.cs
+++ b/Loader.cs
@@ -991,8 +991,8 @@ namespace SongCore
                             if (level != null)
                             {
                                 beatmapDictionary[songPath] = level;
+                                Collections.AddExtraSongData(hash, songPath, songData.RawSongData);
                             }
-                            Collections.AddExtraSongData(hash, songPath, songData.RawSongData);
                         });
                     }
                     catch (Exception ex)


### PR DESCRIPTION
Prior to this PR, ExtraSongData would still be added to the caches, regardless of whether the WIP level could be loaded itself.