### PR TITLE
Fix missing hit sounds issue

### DIFF
--- a/HarmonyPatches/HitSoundPatches.cs
+++ b/HarmonyPatches/HitSoundPatches.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+using UnityEngine;
+
+namespace SongCore.HarmonyPatches
+{
+    [HarmonyPatch(typeof(NoteCutSoundEffectManager), nameof(NoteCutSoundEffectManager.HandleNoteWasSpawned))]
+    internal class NoteCutSoundEffectManagerHandleNoteWasSpawnedPatch
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            // Removes the condition that filters notes that are not in chronological order.
+            return new CodeMatcher(instructions)
+                .MatchForward(false, new CodeMatch(OpCodes.Ldloc_0),
+                    new CodeMatch(OpCodes.Callvirt),
+                    new CodeMatch(OpCodes.Brtrue))
+                .RemoveInstructions(22)
+                .InstructionEnumeration();
+        }
+    }
+
+    [HarmonyPatch(typeof(NoteCutSoundEffect), nameof(NoteCutSoundEffect.Init))]
+    internal class NoteCutSoundEffectInitPatch
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            // Removes the PlayScheduled call from the original method.
+            // Because it plays the sound instantly rather than after the passed delay.
+            return new CodeMatcher(instructions)
+                .MatchForward(false, new CodeMatch(OpCodes.Ldarg_0),
+                    new CodeMatch(OpCodes.Ldfld),
+                    new CodeMatch(OpCodes.Ldarg_0),
+                    new CodeMatch(OpCodes.Ldfld),
+                    new CodeMatch(OpCodes.Callvirt),
+                    new CodeMatch(OpCodes.Ret))
+                .RemoveInstructions(5)
+                .InstructionEnumeration();
+        }
+
+        private static void Postfix(NoteCutSoundEffect __instance, AudioSource ____audioSource, double ____startDSPTime)
+        {
+            __instance.StartCoroutine(PlayHitSoundCoroutine(____audioSource, ____startDSPTime));
+        }
+
+        private static IEnumerator PlayHitSoundCoroutine(AudioSource audioSource, double startDSPTime)
+        {
+            yield return new WaitUntil(() => AudioSettings.dspTime > startDSPTime);
+            audioSource.Play();
+        }
+    }
+}


### PR DESCRIPTION
This fixes an issue where hit sounds are missing. It happens because of two reasons:

- Game is filtering out notes that are spawned out of chronological order.
- Unity has a configured threshold of 32 simultaneous playing sounds before it stops playing them (see [AudioSettings.numRealVoice](https://docs.unity3d.com/ScriptReference/AudioConfiguration-numRealVoices.html)). And `AudioSource.PlayScheduled`, for some reason, plays the sound **instantly** when called rather than waiting for the passed delay. This means that the game plays the hit sound **as soon as the notes spawn**, which is more likely to cause problems with Noodle maps, but can certainly happen with normal ones as well (any map with more than 31 notes displayed at the same time will have missing hit sounds).