### PR TITLE
Fix player data loading to account for custom characteristics

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -89,6 +89,8 @@ namespace SongCore
             Collections.RegisterCustomCharacteristic(BasicUI.MissingCharIcon!, "Missing Characteristic", "Missing Characteristic", "MissingCharacteristic", "MissingCharacteristic", false, false, 1000);
             Collections.RegisterCustomCharacteristic(BasicUI.LightshowIcon!, "Lightshow", "Lightshow", "Lightshow", "Lightshow", false, false, 100);
             Collections.RegisterCustomCharacteristic(BasicUI.ExtraDiffsIcon!, "Lawless", "Lawless - Anything Goes", "Lawless", "Lawless", false, false, 101);
+            // Reload player data to account for custom characteristics.
+            Object.FindObjectOfType<PlayerDataModel>().Load();
 
             var foldersXmlFilePath = Path.Combine(UnityGame.UserDataPath, nameof(SongCore), "folders.xml");
             if (!File.Exists(foldersXmlFilePath))


### PR DESCRIPTION
Currently, the player's save data is loaded before SongCore is loaded, which means that the patch to `GetBeatmapCharacteristicBySerializedName` is not yet applied and so the game will just fail to retrieve the custom characteristics when loading the player data on launch.