### PR TITLE
Allow for assigning environment ColorW + boost

### DIFF
--- a/Data/SongData.cs
+++ b/Data/SongData.cs
@@ -51,8 +51,10 @@ namespace SongCore.Data
             public MapColor? _colorRight;
             public MapColor? _envColorLeft;
             public MapColor? _envColorRight;
+            public MapColor? _envColorWhite;
             public MapColor? _envColorLeftBoost;
             public MapColor? _envColorRightBoost;
+            public MapColor? _envColorWhiteBoost;
             public MapColor? _obstacleColor;
         }
 
@@ -145,8 +147,10 @@ namespace SongCore.Data
                         MapColor? diffRight = null;
                         MapColor? diffEnvLeft = null;
                         MapColor? diffEnvRight = null;
+                        MapColor? diffEnvWhite = null;
                         MapColor? diffEnvLeftBoost = null;
                         MapColor? diffEnvRightBoost = null;
+                        MapColor? diffEnvWhiteBoost = null;
                         MapColor? diffObstacle = null;
 
                         var diffDifficulty = Utils.ToEnum((string) diffBeatmap["_difficulty"], BeatmapDifficulty.Normal);
@@ -203,6 +207,17 @@ namespace SongCore.Data
                                 }
                             }
 
+                            if (beatmapData.TryGetValue("_envColorWhite", out var envColorWhite))
+                            {
+                                if (envColorWhite.Children().Count() == 3)
+                                {
+                                    diffEnvWhite = new MapColor(
+                                        (float) (envColorWhite["r"] ?? 0),
+                                        (float) (envColorWhite["g"] ?? 0),
+                                        (float) (envColorWhite["b"] ?? 0));
+                                }
+                            }
+
                             if (beatmapData.TryGetValue("_envColorLeftBoost", out var envColorLeftBoost))
                             {
                                 if (envColorLeftBoost.Children().Count() == 3)
@@ -222,6 +237,17 @@ namespace SongCore.Data
                                         (float) (envColorRightBoost["r"] ?? 0),
                                         (float) (envColorRightBoost["g"] ?? 0),
                                         (float) (envColorRightBoost["b"] ?? 0));
+                                }
+                            }
+
+                            if (beatmapData.TryGetValue("_envColorWhiteBoost", out var envColorWhiteBoost))
+                            {
+                                if (envColorWhiteBoost.Children().Count() == 3)
+                                {
+                                    diffEnvWhiteBoost = new MapColor(
+                                        (float) (envColorWhiteBoost["r"] ?? 0),
+                                        (float) (envColorWhiteBoost["g"] ?? 0),
+                                        (float) (envColorWhiteBoost["b"] ?? 0));
                                 }
                             }
 
@@ -275,8 +301,10 @@ namespace SongCore.Data
                             _colorRight = diffRight,
                             _envColorLeft = diffEnvLeft,
                             _envColorRight = diffEnvRight,
+                            _envColorWhite = diffEnvWhite,
                             _envColorLeftBoost = diffEnvLeftBoost,
                             _envColorRightBoost = diffEnvRightBoost,
+                            _envColorWhiteBoost = diffEnvWhiteBoost,
                             _obstacleColor = diffObstacle
                         });
                     }

--- a/HarmonyPatches/CustomSongColorsPatch.cs
+++ b/HarmonyPatches/CustomSongColorsPatch.cs
@@ -42,7 +42,7 @@ namespace SongCore.HarmonyPatches
             var envWhite = songData._envColorWhite == null ? fallbackScheme.environmentColorW : Utils.ColorFromMapColor(songData._envColorWhite);
             var envLeftBoost = songData._envColorLeftBoost == null ? envLeft : Utils.ColorFromMapColor(songData._envColorLeftBoost);
             var envRightBoost = songData._envColorRightBoost == null ? envRight : Utils.ColorFromMapColor(songData._envColorRightBoost);
-            var envWhiteBoost = songData._envColorLeftBoost == null ? fallbackScheme.environmentColorWBoost : Utils.ColorFromMapColor(songData._envColorWhiteBoost);
+            var envWhiteBoost = songData._envColorWhiteBoost == null ? fallbackScheme.environmentColorWBoost : Utils.ColorFromMapColor(songData._envColorWhiteBoost);
             var obstacle = songData._obstacleColor == null ? fallbackScheme.obstaclesColor : Utils.ColorFromMapColor(songData._obstacleColor);
             overrideColorScheme = new ColorScheme("SongCoreMapColorScheme", "SongCore Map Color Scheme", true, "SongCore Map Color Scheme", false, saberLeft, saberRight, envLeft,
                 envRight, true, envLeftBoost, envRightBoost, obstacle);

--- a/HarmonyPatches/CustomSongColorsPatch.cs
+++ b/HarmonyPatches/CustomSongColorsPatch.cs
@@ -1,5 +1,7 @@
 using HarmonyLib;
+using IPA.Utilities;
 using SongCore.Utilities;
+using Utils = SongCore.Utilities.Utils;
 
 namespace SongCore.HarmonyPatches
 {
@@ -20,7 +22,7 @@ namespace SongCore.HarmonyPatches
                 return;
             }
 
-            if (songData._colorLeft == null && songData._colorRight == null && songData._envColorLeft == null && songData._envColorRight == null && songData._obstacleColor == null && songData._envColorLeftBoost == null && songData._envColorRightBoost == null)
+            if (songData._colorLeft == null && songData._colorRight == null && songData._envColorLeft == null && songData._envColorRight == null && songData._envColorWhite == null && songData._obstacleColor == null && songData._envColorLeftBoost == null && songData._envColorRightBoost == null && songData._envColorWhiteBoost == null)
             {
                 return;
             }
@@ -37,11 +39,15 @@ namespace SongCore.HarmonyPatches
             var envRight = songData._envColorRight == null
                 ? songData._colorRight == null ? fallbackScheme.environmentColor1 : Utils.ColorFromMapColor(songData._colorRight)
                 : Utils.ColorFromMapColor(songData._envColorRight);
+            var envWhite = songData._envColorWhite == null ? fallbackScheme.environmentColorW : Utils.ColorFromMapColor(songData._envColorWhite);
             var envLeftBoost = songData._envColorLeftBoost == null ? envLeft : Utils.ColorFromMapColor(songData._envColorLeftBoost);
             var envRightBoost = songData._envColorRightBoost == null ? envRight : Utils.ColorFromMapColor(songData._envColorRightBoost);
+            var envWhiteBoost = songData._envColorLeftBoost == null ? fallbackScheme.environmentColorWBoost : Utils.ColorFromMapColor(songData._envColorWhiteBoost);
             var obstacle = songData._obstacleColor == null ? fallbackScheme.obstaclesColor : Utils.ColorFromMapColor(songData._obstacleColor);
             overrideColorScheme = new ColorScheme("SongCoreMapColorScheme", "SongCore Map Color Scheme", true, "SongCore Map Color Scheme", false, saberLeft, saberRight, envLeft,
                 envRight, true, envLeftBoost, envRightBoost, obstacle);
+            overrideColorScheme.SetField("_environmentColorW", envWhite);
+            overrideColorScheme.SetField("_environmentColorWBoost", envWhiteBoost);
         }
     }
 }


### PR DESCRIPTION
This PR allows for assigning the newly added ColorW environment light, as found in 1.22.0. This doesn't work in older versions of the game, but now allows for 1 extra light color and 1 extra boost light color

![Beat_Saber_dfyygo5v9r](https://user-images.githubusercontent.com/87990853/168191442-67f0fefc-584c-44e2-8ef8-c23e9f2f303f.png)
.