### PR TITLE
Split "Allow Custom Song Colors" into separate options

### DIFF
--- a/HarmonyPatches/CustomSongColorsPatch.cs
+++ b/HarmonyPatches/CustomSongColorsPatch.cs
@@ -11,7 +11,7 @@ namespace SongCore.HarmonyPatches
     {
         private static void Prefix(ref IDifficultyBeatmap difficultyBeatmap, ref ColorScheme? overrideColorScheme)
         {
-            if (!Plugin.Configuration.CustomSongColors)
+            if (!Plugin.Configuration.CustomSongNoteColors && !Plugin.Configuration.CustomSongEnvironmentColors && !Plugin.Configuration.CustomSongObstacleColors)
             {
                 return;
             }
@@ -30,20 +30,37 @@ namespace SongCore.HarmonyPatches
             var environmentInfoSO = difficultyBeatmap.GetEnvironmentInfo();
             var fallbackScheme = overrideColorScheme ?? new ColorScheme(environmentInfoSO.colorScheme);
 
-            Logging.Logger.Info("Custom Song Colors On");
-            var saberLeft = songData._colorLeft == null ? fallbackScheme.saberAColor : Utils.ColorFromMapColor(songData._colorLeft);
-            var saberRight = songData._colorRight == null ? fallbackScheme.saberBColor : Utils.ColorFromMapColor(songData._colorRight);
-            var envLeft = songData._envColorLeft == null
-                ? songData._colorLeft == null ? fallbackScheme.environmentColor0 : Utils.ColorFromMapColor(songData._colorLeft)
+            if (Plugin.Configuration.CustomSongNoteColors) Logging.Logger.Info("Custom Song Note Colors On");
+            if (Plugin.Configuration.CustomSongEnvironmentColors) Logging.Logger.Info("Custom Song Environment Colors On");
+            if (Plugin.Configuration.CustomSongObstacleColors) Logging.Logger.Info("Custom Song Obstacle Colors On");
+
+            var saberLeft = (songData._colorLeft == null || !Plugin.Configuration.CustomSongNoteColors)
+                ? fallbackScheme.saberAColor
+                : Utils.ColorFromMapColor(songData._colorLeft);
+            var saberRight = (songData._colorRight == null || !Plugin.Configuration.CustomSongNoteColors)
+                ? fallbackScheme.saberBColor
+                : Utils.ColorFromMapColor(songData._colorRight);
+            var envLeft = (songData._envColorLeft == null || !Plugin.Configuration.CustomSongEnvironmentColors)
+                ? fallbackScheme.environmentColor0
                 : Utils.ColorFromMapColor(songData._envColorLeft);
-            var envRight = songData._envColorRight == null
-                ? songData._colorRight == null ? fallbackScheme.environmentColor1 : Utils.ColorFromMapColor(songData._colorRight)
+            var envRight = (songData._envColorRight == null || !Plugin.Configuration.CustomSongEnvironmentColors)
+                ? fallbackScheme.environmentColor1
                 : Utils.ColorFromMapColor(songData._envColorRight);
-            var envWhite = songData._envColorWhite == null ? fallbackScheme.environmentColorW : Utils.ColorFromMapColor(songData._envColorWhite);
-            var envLeftBoost = songData._envColorLeftBoost == null ? envLeft : Utils.ColorFromMapColor(songData._envColorLeftBoost);
-            var envRightBoost = songData._envColorRightBoost == null ? envRight : Utils.ColorFromMapColor(songData._envColorRightBoost);
-            var envWhiteBoost = songData._envColorWhiteBoost == null ? fallbackScheme.environmentColorWBoost : Utils.ColorFromMapColor(songData._envColorWhiteBoost);
-            var obstacle = songData._obstacleColor == null ? fallbackScheme.obstaclesColor : Utils.ColorFromMapColor(songData._obstacleColor);
+            var envWhite = (songData._envColorWhite == null || !Plugin.Configuration.CustomSongEnvironmentColors)
+                ? fallbackScheme.environmentColorW
+                : Utils.ColorFromMapColor(songData._envColorWhite);
+            var envLeftBoost = (songData._envColorLeftBoost == null || !Plugin.Configuration.CustomSongEnvironmentColors)
+                ? fallbackScheme.environmentColor0Boost
+                : Utils.ColorFromMapColor(songData._envColorLeftBoost);
+            var envRightBoost = (songData._envColorRightBoost == null|| !Plugin.Configuration.CustomSongEnvironmentColors)
+                ? fallbackScheme.environmentColor1Boost
+                : Utils.ColorFromMapColor(songData._envColorRightBoost);
+            var envWhiteBoost = (songData._envColorWhiteBoost == null  || !Plugin.Configuration.CustomSongEnvironmentColors)
+                ? fallbackScheme.environmentColorWBoost
+                : Utils.ColorFromMapColor(songData._envColorWhiteBoost);
+            var obstacle = (songData._obstacleColor == null || !Plugin.Configuration.CustomSongObstacleColors)
+                ? fallbackScheme.obstaclesColor
+                : Utils.ColorFromMapColor(songData._obstacleColor);
             overrideColorScheme = new ColorScheme("SongCoreMapColorScheme", "SongCore Map Color Scheme", true, "SongCore Map Color Scheme", false, saberLeft, saberRight, envLeft,
                 envRight, true, envLeftBoost, envRightBoost, obstacle);
             overrideColorScheme.SetField("_environmentColorW", envWhite);

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -48,7 +48,9 @@ namespace SongCore
             {
                 var modPrefs = new BS_Utils.Utilities.Config("SongCore/SongCore");
 
-                Configuration.CustomSongColors = modPrefs.GetBool("SongCore", "customSongColors", true, true);
+                Configuration.CustomSongNoteColors = modPrefs.GetBool("SongCore", "customSongNoteColors", true, true);
+                Configuration.CustomSongObstacleColors = modPrefs.GetBool("SongCore", "customSongObstacleColors", true, true);
+                Configuration.CustomSongEnvironmentColors = modPrefs.GetBool("SongCore", "customSongEnvironmentColors", true, true);
                 Configuration.CustomSongPlatforms = modPrefs.GetBool("SongCore", "customSongPlatforms", true, true);
                 Configuration.DisplayDiffLabels = modPrefs.GetBool("SongCore", "displayDiffLabels", true, true);
                 Configuration.ForceLongPreviews = modPrefs.GetBool("SongCore", "forceLongPreviews", false, true);

--- a/SConfiguration.cs
+++ b/SConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using IPA.Config.Stores;
 
 [assembly: InternalsVisibleTo(GeneratedStore.AssemblyVisibilityTarget)]
@@ -6,7 +6,9 @@ namespace SongCore
 {
     internal class SConfiguration
     {
-        public virtual bool CustomSongColors { get; set; } = true;
+        public virtual bool CustomSongNoteColors { get; set; } = true;
+        public virtual bool CustomSongObstacleColors { get; set; } = true;
+        public virtual bool CustomSongEnvironmentColors { get; set; } = true;
         public virtual bool CustomSongPlatforms { get; set; } = true;
         public virtual bool DisplayDiffLabels { get; set; } = true;
         public virtual bool ForceLongPreviews { get; set; } = true;

--- a/UI/ColorsUI.cs
+++ b/UI/ColorsUI.cs
@@ -24,11 +24,25 @@ namespace SongCore.UI
         [UIComponent("selected-color")]
         private readonly RectTransform selectedColorTransform;
 
-        [UIValue("colors")]
-        public bool Colors
+        [UIValue("noteColors")]
+        public bool NoteColors
         {
-            get => Plugin.Configuration.CustomSongColors;
-            set => Plugin.Configuration.CustomSongColors = value;
+            get => Plugin.Configuration.CustomSongNoteColors;
+            set => Plugin.Configuration.CustomSongNoteColors = value;
+        }
+
+        [UIValue("obstacleColors")]
+        public bool ObstacleColors
+        {
+            get => Plugin.Configuration.CustomSongObstacleColors;
+            set => Plugin.Configuration.CustomSongObstacleColors = value;
+        }
+
+        [UIValue("environmentColors")]
+        public bool EnvironmentColors
+        {
+            get => Plugin.Configuration.CustomSongEnvironmentColors;
+            set => Plugin.Configuration.CustomSongEnvironmentColors = value;
         }
 
         internal void ShowColors(ExtraSongData.DifficultyData songData)
@@ -68,14 +82,10 @@ namespace SongCore.UI
         {
             Color saberLeft = songData._colorLeft == null ? voidColor : Utils.ColorFromMapColor(songData._colorLeft);
             Color saberRight = songData._colorRight == null ? voidColor : Utils.ColorFromMapColor(songData._colorRight);
-            Color envLeft = songData._envColorLeft == null
-                ? songData._colorLeft == null ? voidColor : Utils.ColorFromMapColor(songData._colorLeft)
-                : Utils.ColorFromMapColor(songData._envColorLeft);
-            Color envRight = songData._envColorRight == null
-                ? songData._colorRight == null ? voidColor : Utils.ColorFromMapColor(songData._colorRight)
-                : Utils.ColorFromMapColor(songData._envColorRight);
-            var envLeftBoost = songData._envColorLeftBoost == null ? voidColor : Utils.ColorFromMapColor(songData._envColorLeftBoost);
-            var envRightBoost = songData._envColorRightBoost == null ? voidColor : Utils.ColorFromMapColor(songData._envColorRightBoost);
+            Color envLeft = songData._envColorLeft == null ? voidColor : Utils.ColorFromMapColor(songData._envColorLeft);
+            Color envRight = songData._envColorRight == null ? voidColor : Utils.ColorFromMapColor(songData._envColorRight);
+            Color envLeftBoost = songData._envColorLeftBoost == null ? voidColor : Utils.ColorFromMapColor(songData._envColorLeftBoost);
+            Color envRightBoost = songData._envColorRightBoost == null ? voidColor : Utils.ColorFromMapColor(songData._envColorRightBoost);
             Color obstacle = songData._obstacleColor == null ? voidColor : Utils.ColorFromMapColor(songData._obstacleColor);
 
             colorSchemeView.SetColors(saberLeft, saberRight, envLeft, envRight, envLeftBoost, envRightBoost, obstacle);

--- a/UI/RequirementsUI.cs
+++ b/UI/RequirementsUI.cs
@@ -190,7 +190,7 @@ namespace SongCore.UI
             {
                 if (Utils.DiffHasColors(diffData))
                 {
-                    customListTableData.data.Add(new CustomCellInfo($"<size=75%>Custom Colors Available", $"Click here to preview & {(Plugin.Configuration.CustomSongColors ? "disable" : "enable")} it.", ColorsIcon));
+                    customListTableData.data.Add(new CustomCellInfo($"<size=75%>Custom Colors Available", $"Click here to preview & enable or disable it.", ColorsIcon));
                 }
 
                 if (diffData.additionalDifficultyData._warnings.Length > 0)

--- a/UI/SCSettingsController.cs
+++ b/UI/SCSettingsController.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using BeatSaberMarkupLanguage.Attributes;
 using JetBrains.Annotations;
@@ -7,13 +7,35 @@ namespace SongCore.UI
 {
     internal class SCSettingsController : INotifyPropertyChanged
     {
-        [UIValue("colors")]
-        public bool Colors
+        [UIValue("noteColors")]
+        public bool NoteColors
         {
-            get => Plugin.Configuration.CustomSongColors;
+            get => Plugin.Configuration.CustomSongNoteColors;
             set
             {
-                Plugin.Configuration.CustomSongColors = value;
+                Plugin.Configuration.CustomSongNoteColors = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [UIValue("obstacleColors")]
+        public bool ObstacleColors
+        {
+            get => Plugin.Configuration.CustomSongObstacleColors;
+            set
+            {
+                Plugin.Configuration.CustomSongObstacleColors = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [UIValue("environmentColors")]
+        public bool EnvironmentColors
+        {
+            get => Plugin.Configuration.CustomSongEnvironmentColors;
+            set
+            {
+                Plugin.Configuration.CustomSongEnvironmentColors = value;
                 OnPropertyChanged();
             }
         }

--- a/UI/colors.bsml
+++ b/UI/colors.bsml
@@ -1,6 +1,8 @@
-<modal id='modal' anchor-pos-x='-5' anchor-pos-y='5' clickerino-offerino-closerino='false' size-delta-x='85' size-delta-y='25' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
+<modal id='modal' anchor-pos-x='-5' anchor-pos-y='5' clickerino-offerino-closerino='false' size-delta-x='85' size-delta-y='30' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
     <vertical horizontal-fit='PreferredSize' pref-width='80'>
-        <checkbox-setting text='Allow Custom Song Colors' value='colors' hover-hint='Allow Custom Songs to override note/light colors.' apply-on-change='true' bind-value='true' />
+        <checkbox-setting text='Allow Custom Song Note Colors' value='noteColors' hover-hint='Allow Custom Songs to override note colors' apply-on-change='true' bind-value='true' />
+        <checkbox-setting text='Allow Custom Song Obstacle Colors' value='obstacleColors' hover-hint='Allow Custom Songs to override wall colors' apply-on-change='true' bind-value='true' />
+        <checkbox-setting text='Allow Custom Song Environment Colors' value='environmentColors' hover-hint='Allow Custom Songs to override light colors' apply-on-change='true' bind-value='true' />
         <horizontal spacing='-5'>
             <text text='Selected Custom Song&#39;s Colors' italics='true' />
             <background id='selected-color' />

--- a/UI/settings.bsml
+++ b/UI/settings.bsml
@@ -1,6 +1,8 @@
 <settings-container xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
                     xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
-    <checkbox-setting text='Allow Custom Song Colors' value='colors' hover-hint='Allow Custom Songs to override note/light colors if Custom Colors or Chroma is installed' bind-value='true' />
+    <checkbox-setting text='Allow Custom Song Note Colors' value='noteColors' hover-hint='Allow Custom Songs to override note colors' bind-value='true' />
+    <checkbox-setting text='Allow Custom Song Obstacle Colors' value='obstacleColors' hover-hint='Allow Custom Songs to override obstacle colors' bind-value='true' />
+    <checkbox-setting text='Allow Custom Song Environment Colors' value='environmentColors' hover-hint='Allow Custom Songs to override environment colors' bind-value='true' />
     <checkbox-setting text='Custom Song Platforms ' value='platforms' hover-hint='Allow Custom Songs to override your Custom Platform if Custom Platforms is installed.'/>
     <checkbox-setting text='Display Custom Difficulty Labels' value='diffLabels' hover-hint='Display Custom Difficulty Labels if used by the mapper.'/>
     <checkbox-setting text='Force Long Song Previews' value='longPreviews'


### PR DESCRIPTION
Resolves #99.

Also not sure what the intent was behind why boost fallbacked to envLeft and envRight and why environment colours checked for saber colours previously.

UI:
![image](https://user-images.githubusercontent.com/68104413/209422293-7ff3f8a8-8d9b-4a0a-ab18-e324dfe5cd81.png)
