### PR TITLE
Bugfix/better corruption handling during loading

### DIFF
--- a/Loader.cs
+++ b/Loader.cs
@@ -383,9 +383,10 @@ namespace SongCore
                           {
                               results = Directory.GetFiles(folder, "info.dat", SearchOption.TopDirectoryOnly);
                           }
-                          catch (DirectoryNotFoundException)
+                          catch (Exception ex)
                           {
                               Logging.Logger.Warn($"Skipping missing or corrupt folder: '{folder}'");
+                              Logging.Logger.Warn(ex);
                               return;
                           }
 
@@ -485,9 +486,10 @@ namespace SongCore
                                 {
                                     results = Directory.GetFiles(folder, "info.dat", SearchOption.TopDirectoryOnly);
                                 }
-                                catch (DirectoryNotFoundException)
+                                catch (Exception ex)
                                 {
                                     Logging.Logger.Warn($"Skipping missing or corrupt folder: '{folder}'");
+                                    Logging.Logger.Warn(ex);
                                     continue;
                                 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "gameVersion": "1.27.0",
     "id": "SongCore",
     "name": "SongCore",
-    "version": "3.9.8",
+    "version": "3.9.9",
     "dependsOn": {
         "BeatSaberMarkupLanguage": "^1.6.0",
         "BSIPA": "^4.2.1",


### PR DESCRIPTION
A player reported that a lot of songs would not get loaded due to some unknown reason, but after inspecting the logs. It turned out that some of the beatmaps had corrupted, which resulted in the whole loading process getting aborted instead of just skipping the affected beatmap.
This changes the behavior so only the affected beatmaps get skipped.