### PR TITLE
Fix for patch 1.28.0

### DIFF
--- a/Collections.cs
+++ b/Collections.cs
@@ -77,10 +77,22 @@ namespace SongCore
             return diffData;
         }
 
-        internal static async Task LoadExtraSongDataAsync()
+        internal static void LoadExtraSongData()
         {
-            using var reader = new StreamReader(DataPath);
-            CustomSongsData = JsonConvert.DeserializeObject<ConcurrentDictionary<string, ExtraSongData>?>(await reader.ReadToEndAsync()) ?? new ConcurrentDictionary<string, ExtraSongData>();
+            Task.Run(() =>
+            {
+                try
+                {
+                    using var reader = new JsonTextReader(new StreamReader(DataPath));
+                    var serializer = JsonSerializer.CreateDefault();
+                    CustomSongsData = serializer.Deserialize<ConcurrentDictionary<string, ExtraSongData>?>(reader) ?? new ConcurrentDictionary<string, ExtraSongData>();
+                }
+                catch (Exception ex)
+                {
+                    Logging.Logger.Error($"Error loading extra song data: {ex.Message}");
+                    Logging.Logger.Debug(ex);
+                }
+            });
         }
 
         internal static async Task SaveExtraSongDataAsync()

--- a/Collections.cs
+++ b/Collections.cs
@@ -90,7 +90,7 @@ namespace SongCore
                 catch (Exception ex)
                 {
                     Logging.Logger.Error($"Error loading extra song data: {ex.Message}");
-                    Logging.Logger.Debug(ex);
+                    Logging.Logger.Error(ex);
                 }
             });
         }

--- a/Loader.cs
+++ b/Loader.cs
@@ -295,7 +295,7 @@ namespace SongCore
                 catch (Exception ex)
                 {
                     Logging.Logger.Error($"Error populating official songs: {ex.Message}");
-                    Logging.Logger.Debug(ex);
+                    Logging.Logger.Error(ex);
                 }
 
                 #endregion

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -6,7 +6,6 @@ using SongCore.Utilities;
 using IPA.Utilities;
 using System;
 using System.IO;
-using System.Threading.Tasks;
 using IPA.Config;
 using IPA.Config.Stores;
 using IPA.Loader;
@@ -43,7 +42,7 @@ namespace SongCore
         }
 
         [OnStart]
-        public async Task OnApplicationStartAsync()
+        public void OnApplicationStart()
         {
             // TODO: Remove this migration path at some point
             var songCoreIniPath = Path.Combine(UnityGame.UserDataPath, nameof(SongCore), "SongCore.ini");
@@ -85,7 +84,7 @@ namespace SongCore
             }
             else
             {
-                await Collections.LoadExtraSongDataAsync();
+                Collections.LoadExtraSongData();
             }
 
             Collections.RegisterCustomCharacteristic(BasicUI.MissingCharIcon!, "Missing Characteristic", "Missing Characteristic", "MissingCharacteristic", "MissingCharacteristic", false, false, 1000);

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -90,8 +90,6 @@ namespace SongCore
             Collections.RegisterCustomCharacteristic(BasicUI.MissingCharIcon!, "Missing Characteristic", "Missing Characteristic", "MissingCharacteristic", "MissingCharacteristic", false, false, 1000);
             Collections.RegisterCustomCharacteristic(BasicUI.LightshowIcon!, "Lightshow", "Lightshow", "Lightshow", "Lightshow", false, false, 100);
             Collections.RegisterCustomCharacteristic(BasicUI.ExtraDiffsIcon!, "Lawless", "Lawless - Anything Goes", "Lawless", "Lawless", false, false, 101);
-            // Reload player data to account for custom characteristics.
-            Object.FindObjectOfType<PlayerDataModel>().Load();
 
             var foldersXmlFilePath = Path.Combine(UnityGame.UserDataPath, nameof(SongCore), "folders.xml");
             if (!File.Exists(foldersXmlFilePath))


### PR DESCRIPTION
Now that Beat Games added back the loading screen, mods are loaded before the game loads the `PlayerData`, making #88 not needed anymore, as SongCore patches are applied once again before that data is loaded.

See #105 for details. We need a better implementation for that specific issue, anyway. 