### PR TITLE
Remove custom song color config migration

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -49,9 +49,6 @@ namespace SongCore
             {
                 var modPrefs = new BS_Utils.Utilities.Config("SongCore/SongCore");
 
-                Configuration.CustomSongNoteColors = modPrefs.GetBool("SongCore", "customSongNoteColors", true, true);
-                Configuration.CustomSongObstacleColors = modPrefs.GetBool("SongCore", "customSongObstacleColors", true, true);
-                Configuration.CustomSongEnvironmentColors = modPrefs.GetBool("SongCore", "customSongEnvironmentColors", true, true);
                 Configuration.CustomSongPlatforms = modPrefs.GetBool("SongCore", "customSongPlatforms", true, true);
                 Configuration.DisplayDiffLabels = modPrefs.GetBool("SongCore", "displayDiffLabels", true, true);
                 Configuration.ForceLongPreviews = modPrefs.GetBool("SongCore", "forceLongPreviews", false, true);


### PR DESCRIPTION
Mentioned in https://github.com/Kylemc1413/SongCore/pull/102#issuecomment-1445211574, this is a migration from an old config system so these lines are not needed.

On the off chance someone is migrating from an old config, I'd want to reset this setting to default instead of preserving it as the options are more granular than before.