### PR TITLE
Change cache management to use relative path

### DIFF
--- a/Loader.cs
+++ b/Loader.cs
@@ -268,7 +268,7 @@ namespace SongCore
 
             ConcurrentDictionary<string, bool> foundSongPaths = fullRefresh
                 ? new ConcurrentDictionary<string, bool>()
-                : new ConcurrentDictionary<string, bool>(Hashing.cachedSongHashData.Keys.ToDictionary(x => x, _ => false));
+                : new ConcurrentDictionary<string, bool>(Hashing.cachedSongHashData.Keys.ToDictionary(Hashing.GetAbsolutePath, _ => false));
 
             Action job = () =>
             {
@@ -1134,7 +1134,7 @@ namespace SongCore
             {
                 string levelid = level.levelID;
                 float length = 0;
-                if (Hashing.cachedAudioData.TryGetValue(songPath, out var data))
+                if (Hashing.cachedAudioData.TryGetValue(Hashing.GetRelativePath(songPath), out var data))
                 {
                     if (data.id == levelid)
                     {
@@ -1168,7 +1168,7 @@ namespace SongCore
                 }
                 else
                 {
-                    Hashing.cachedAudioData[songPath] = new AudioCacheData(levelid, length);
+                    Hashing.cachedAudioData[Hashing.GetRelativePath(songPath)] = new AudioCacheData(levelid, length);
                 }
 
                 Accessors.SongDurationSetter(ref level) = length;

--- a/Utilities/Hashing.cs
+++ b/Utilities/Hashing.cs
@@ -43,7 +43,7 @@ namespace SongCore.Utilities
         {
             foreach (var hashData in cachedSongHashData.ToArray())
             {
-                if (!currentSongPaths.Contains(GetAbsolutePath(hashData.Key)) || GetAbsolutePath(hashData.Key) == hashData.Key)
+                if (!currentSongPaths.Contains(GetAbsolutePath(hashData.Key)) || (GetAbsolutePath(hashData.Key) == hashData.Key && IsInInstallPath(hashData.Key)))
                 {
                     cachedSongHashData.TryRemove(hashData.Key, out _);
                 }
@@ -80,7 +80,7 @@ namespace SongCore.Utilities
         {
             foreach (var hashData in cachedAudioData.ToArray())
             {
-                if (!currentSongPaths.Contains(GetAbsolutePath(hashData.Key)) || GetAbsolutePath(hashData.Key) == hashData.Key)
+                if (!currentSongPaths.Contains(GetAbsolutePath(hashData.Key)) || (GetAbsolutePath(hashData.Key) == hashData.Key && IsInInstallPath(hashData.Key)))
                 {
                     cachedAudioData.TryRemove(hashData.Key, out _);
                 }
@@ -194,6 +194,18 @@ namespace SongCore.Utilities
             }
 
             return relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        }
+
+        public static bool IsInInstallPath(string path)
+        {
+            string fromPath = IPA.Utilities.UnityGame.InstallPath;
+
+            if (!fromPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            {
+                fromPath += Path.DirectorySeparatorChar;
+            }
+
+            return path.StartsWith(fromPath);
         }
 
         // Black magic https://stackoverflow.com/questions/311165/how-do-you-convert-a-byte-array-to-a-hexadecimal-string-and-vice-versa/14333437#14333437


### PR DESCRIPTION
Just a small improvement using a relative path if the folder is in the install folder to prevent SongCore from reloading all files when the game install is moved or if the UserData and CustomLevels folders are shared across multiple beat saber installs.