### PR TITLE
Fix exception on null difficultyBeatmap

### DIFF
--- a/HarmonyPatches/CustomSongColorsPatch.cs
+++ b/HarmonyPatches/CustomSongColorsPatch.cs
@@ -47,7 +47,7 @@ namespace SongCore.HarmonyPatches
 
         private static void Prefix(ref IDifficultyBeatmap difficultyBeatmap, ref ColorScheme? overrideColorScheme)
         {
-            if (!Plugin.Configuration.CustomSongNoteColors && !Plugin.Configuration.CustomSongEnvironmentColors && !Plugin.Configuration.CustomSongObstacleColors)
+            if (difficultyBeatmap == null || !Plugin.Configuration.CustomSongNoteColors && !Plugin.Configuration.CustomSongEnvironmentColors && !Plugin.Configuration.CustomSongObstacleColors)
             {
                 return;
             }


### PR DESCRIPTION
This fixes the blackscreening in multiplayer when joining a lobby where a map is currently being played that can't be loaded, for example a DLC map that you don't own.