### PR TITLE
Fix/restore environment color override behavior

### DIFF
--- a/HarmonyPatches/CustomSongColorsPatch.cs
+++ b/HarmonyPatches/CustomSongColorsPatch.cs
@@ -77,10 +77,10 @@ namespace SongCore.HarmonyPatches
                 ? fallbackScheme.saberBColor
                 : Utils.ColorFromMapColor(songData._colorRight);
             var envLeft = (songData._envColorLeft == null || !Plugin.Configuration.CustomSongEnvironmentColors)
-                ? fallbackScheme.environmentColor0
+                ? songData._colorLeft == null ? fallbackScheme.environmentColor0 : Utils.ColorFromMapColor(songData._colorLeft)
                 : Utils.ColorFromMapColor(songData._envColorLeft);
             var envRight = (songData._envColorRight == null || !Plugin.Configuration.CustomSongEnvironmentColors)
-                ? fallbackScheme.environmentColor1
+                ? songData._colorRight == null ? fallbackScheme.environmentColor1 : Utils.ColorFromMapColor(songData._colorRight)
                 : Utils.ColorFromMapColor(songData._envColorRight);
             var envWhite = (songData._envColorWhite == null || !Plugin.Configuration.CustomSongEnvironmentColors)
                 ? fallbackScheme.environmentColorW


### PR DESCRIPTION
At previous versions environment/light colors inherited note colors if the map didn't set it. This was changed with commit [d92ec06](https://github.com/Kylemc1413/SongCore/commit/d92ec06c4c7fec6048c376f5e238cd98d42185e6). With the current version it inherits the default colors if neither the map sets it explicitly, nor the user overrides it with custom colors.

I don't know if the change was intentional or not, this commit simply restores the previous behavior (fixes issue #111 created by me).