### PR TITLE
Fix CI workflow triggering on incorrect branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,10 +19,10 @@ name: pr build
 on:
     push:
         branches:
-            - main
+            - master
     pull_request:
         branches:
-            - main
+            - master
 
 jobs:
     workflow:

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -10,8 +10,8 @@ using Nuke.Common.CI.GitHubActions;
 	FetchDepth = 0, // Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Make sure to fetch whole git history, in order to get GitVersion to work.
 	ImportSecrets = new[] { "SIRA_SERVER_CODE" },
 	InvokedTargets = new[] { nameof(Compile) },
-	OnPushBranches = new[] { "main" },
-	OnPullRequestBranches = new[] { "main" },
+	OnPushBranches = new[] { "master" },
+	OnPullRequestBranches = new[] { "master" },
 	PublishArtifacts = true)]
 [GitHubActions(
 	"publish",


### PR DESCRIPTION
Accidentally triggering on `main` instead of `master`