### PR TITLE
Add missing alpha value in color

### DIFF
--- a/source/SongCore/Utilities/Utils.cs
+++ b/source/SongCore/Utilities/Utils.cs
@@ -22,7 +22,7 @@ namespace SongCore.Utilities
 
         public static Color ColorFromMapColor(Data.ExtraSongData.MapColor mapColor)
         {
-            return new Color(mapColor.r, mapColor.g, mapColor.b);
+            return new Color(mapColor.r, mapColor.g, mapColor.b, mapColor.a);
         }
 
         public static TEnum ToEnum<TEnum>(this string strEnumValue, TEnum defaultValue)


### PR DESCRIPTION
somehow this got slipped past for long while, figured why my light was oddly dim ingame vs editor

shouldnt be an issue for MapColor `a` value seeing it has already been handled elsewhere