### PR TITLE
Patch out legacy BPM events support

### DIFF
--- a/source/SongCore/HarmonyPatches/YeetLegacyBPMEventsPatch.cs
+++ b/source/SongCore/HarmonyPatches/YeetLegacyBPMEventsPatch.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using BeatmapSaveDataCommon;
+using HarmonyLib;
+using JetBrains.Annotations;
+
+namespace SongCore.HarmonyPatches
+{
+    // Event10 was briefly used as an official BPM change between 1.8.0 and 1.18.0,
+    // but it was never supported by custom mapping tools and later reused as a light event.
+    // The code to convert these events broke a lot of maps, so we are removing it here.
+    [HarmonyPatch(typeof(BeatmapSaveDataVersion2_6_0AndEarlier.BeatmapSaveData), nameof(BeatmapSaveDataVersion2_6_0AndEarlier.BeatmapSaveData.ConvertBeatmapSaveDataPreV2_5_0Inline))]
+    [UsedImplicitly]
+    public static class YeetLegacyBPMEventsPatch
+    {
+        // Skipping the:
+        // if (eventData.type == BeatmapEventType.Event10)
+        //    eventData = new EventData(eventData.time, BeatmapEventType.BpmChange, eventData.value, eventData.floatValue);
+        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+            bool skip = false;
+
+            for (int i = 0; i < codes.Count; i++)
+            {
+                // Checks for the loading onto the stack, which precedes the condition check.
+                if (codes[i].opcode == OpCodes.Ldc_I4_S && i < codes.Count - 1 && codes[i + 1].opcode == OpCodes.Bne_Un)
+                {
+                    // Skip everything from loading Event10...
+                    if ((sbyte)codes[i].operand == (sbyte)BeatmapEventType.Event10) {
+                        skip = true;
+                    // ...to loading proper BPM event
+                    } else if (skip && (sbyte)codes[i].operand == (sbyte)BeatmapEventType.BpmChange) {
+                        skip = false;
+                    }
+                }
+
+                if (!skip)
+                {
+                    yield return codes[i];
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Event with a `type` 10 was introduced as an official BPM change event in 1.8.0 and later reused as a light in 1.18.0. This change disables the conversion of legacy BPM changes to add support for maps with type 10 events as lights, but with a wrong map version.

From the collection of 170k recently (last 2 years) played maps, there were 226 broken maps because of the conversion. Some are quite popular, and 2 ranked maps (1 on BL and 1 on SS). And not a single map that properly utilized these events as BPM changes.
Popular mapping tools (MM/custom saber/CM) never had support for this event, and mappers who tried to use them manually were complaining, so I couldn't even find an example map, let alone a map anyone plays.