### PR TITLE
fix System.InvalidOperationException exception for 1.40.3/1.40.4 when reloading songs

### DIFF
--- a/source/SongCore/Loader.cs
+++ b/source/SongCore/Loader.cs
@@ -455,12 +455,18 @@ namespace SongCore
                                     .Where(d => d.Exists && !d.Attributes.HasFlag(FileAttributes.Hidden))
                                     .Select(d => d.FullName)))
                             .ToHashSet();
+                        List<string> folderPathsToRemove = [];
                         foreach (var loadedSaveData in _customLevelLoader._loadedBeatmapSaveData.Values)
                         {
                             if (!folders.Contains(loadedSaveData.customLevelFolderInfo.folderPath))
                             {
-                                DeleteSingleSong(loadedSaveData.customLevelFolderInfo.folderPath, false);
+                                folderPathsToRemove.Add(loadedSaveData.customLevelFolderInfo.folderPath);
                             }
+                        }
+
+                        foreach (string? folderPath in folderPathsToRemove)
+                        {
+                            DeleteSingleSong(folderPath, false);
                         }
                     }
 

--- a/source/SongCore/SongCore.csproj
+++ b/source/SongCore/SongCore.csproj
@@ -32,6 +32,10 @@
       <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="AdditionalContentModel.Interfaces">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\AdditionalContentModel.Interfaces.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
     <Reference Include="BeatmapCore" />
     <Reference Include="BeatSaber.ViewSystem" />
     <Reference Include="BGLib.AppFlow" />


### PR DESCRIPTION
Was running into a `System.InvalidOperationException` every time I reloaded songs with both the current public version of SongCore and the version available in the dev branch on 1.40.4 and 1.40.3.
```
[INFO @ 23:12:45 | SongCore] Starting song refresh
[ERROR @ 23:12:45 | SongCore] RetrieveAllSongs failed:
[ERROR @ 23:12:45 | SongCore] System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
[ERROR @ 23:12:45 | SongCore]   at System.Collections.Generic.Dictionary`2+ValueCollection+Enumerator[TKey,TValue].MoveNext () [0x00013] in <51fded79cd284d4d911c5949aff4cb21>:0 
[ERROR @ 23:12:45 | SongCore]   at SongCore.Loader+<>c__DisplayClass93_0.<RetrieveAllSongs>b__1 () [0x003a7] in C:\Users\Meivyn\Downloads\SongCore\source\SongCore\Loader.cs:473 
[INFO @ 23:12:45 | SongCore] Loaded 2 new songs (2) in CustomLevels | 0 in separate folders) in 0.0375272 seconds
```
Been a thorn in my side so I patched around it, most of the stuff I was looking up mentioned using `lock` in some capacity, but was unsure how the `lock()` function works. I took the easier way out and moved the `DeleteSingleSong` call outside of the loop, using a collection that doesn't get modified.

Build was complaining about the added reference.

~~honestly terrified of submitting a PR to SongCore, the annoyance got to me enough lol~~